### PR TITLE
fix(ci): codecov-action を v6.0.2(SHA固定)に更新し fail_ci_if_error を true に復元

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,12 +66,12 @@ jobs:
           fi
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   build:

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -90,12 +90,12 @@ jobs:
           fi
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
   pre-commit:


### PR DESCRIPTION
## 概要

codecov の GPG 鍵不具合は **v6.0.2（2026-06-07 リリース）で修正済み**。
SHA 固定で恒久対応に切り替え、`fail_ci_if_error` を `true` に復元する。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| action 参照 | `codecov/codecov-action@v6` | `codecov/codecov-action@fb8b3582...` (`# v6.0.2`) |
| fail_ci_if_error | `false`（暫定回避） | `true`（本来の設定に復元） |

対象ファイル: `ci-cd.yml`、`quality-check.yml`（2ファイル同時更新）

## SHA 固定の理由

浮動タグ（`@v6`）は再び書き換えられるリスクがある。commit SHA 固定により、検証済みのバイナリのみを実行することを保証する。

## 参考

- [codecov/codecov-action v6.0.2 リリースノート](https://github.com/codecov/codecov-action/releases/tag/v6.0.2)

Generated with [Claude Code](https://claude.com/claude-code)