### PR TITLE
fix(lint): ignore PLR0917 to fix Renovate CI failures from ruff 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ ignore = [
     "FBT003",  # Boolean positional value in call (needed for GTK/GIMP APIs)
     "TC003",   # Move stdlib import into TYPE_CHECKING (false positive for Path)
     "PLR0913", # Too many arguments (GIMP API signatures require this)
+    "PLR0917", # Too many positional arguments (GIMP API signatures require this)
     "BLE001",  # Blind exception catch (needed for robust error handling)
     "DTZ011",  # datetime.date.today() (acceptable for file naming)
     "TRY300",  # Consider moving to else block (doesn't improve clarity)


### PR DESCRIPTION
## Summary

- ruff 0.16.0 が `PLR0917`（Too many positional arguments > 5）ルールを新たに有効化したことで、Renovate PR #67 と #69 の CI（`quality` / `pre-commit` ジョブ）が失敗していた
- `pyproject.toml` の ruff ignore リストに `PLR0917` を追加し、既存の `PLR0913` 免除と同様に扱うことで修正

## 背景

GIMP API のメソッドシグネチャは設計上6引数以上が必要なケースがあり、`PLR0913`（Too many arguments）は同じ理由で既に ignore 済み。`PLR0917` も同じ GIMP API の制約に起因するため、同様に ignore することが適切。

**違反が検出されていた箇所（計12件）:**
- `src/tachograph_wizard/core/background_remover.py:201`
- `src/tachograph_wizard/core/exporter.py:249`
- `src/tachograph_wizard/core/image_operations.py:67`, `:105`
- `src/tachograph_wizard/core/image_splitter.py:111`, `:405`
- `tests/unit/test_exporter_extended.py`（6箇所）

## 変更内容

`pyproject.toml` の `[tool.ruff.lint]` ignore リストに1行追加:

```toml
"PLR0917", # Too many positional arguments (GIMP API signatures require this)
```

## 関連 PR

- Renovate PR #67: `chore(deps-python): update dependency ruff to >=0.16.0`
- Renovate PR #69: `chore(deps): lock file maintenance`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxxnDi8o3iAn6NS54W5GeD)_