### PR TITLE
fix(lint): exclude Markdown from ruff format to fix ruff 0.16.0 CI failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 このドキュメントは現行仕様の要約と変更履歴を記載します。
 
 ## [Unreleased]
+### 修正
+- **ruff 0.16.0対応**: Markdown内Pythonコードブロックが整形対象になったことによるCI失敗を修正（`[tool.ruff.format]`で`*.md`を除外）
+
 ### 変更
 - **pre-commitのCI同等化**: `ruff format --check` / `ruff check` / `basedpyright` / `pytest` / `bandit` をpre-commitで実行するよう更新
 - **Threshold Bias初期値の見直し**: Chart WizardのSplit Imagesでしきい値スライダー初期値を15に変更し、UI表記を実際のデフォルト挙動に合わせて明確化

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,11 @@ exclude = [
     "venv",
 ]
 
+[tool.ruff.format]
+# ruff 0.16.0 以降は Markdown 内の Python コードブロックも整形対象になるが、
+# docs 配下は擬似コード断片を含む記録文書のため対象外とする
+exclude = ["*.md"]
+
 [tool.pytest.ini_options]
 addopts = "-p pytest_cov --cov=src --cov-report=xml --cov-report=term-missing"
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- ruff 0.16.0 から **Markdown 内の Python コードブロックが `ruff format` の対象**になり、`docs/Completed` 配下の 5 ファイルが未整形と判定されて Renovate PR #67 / #69 の `quality` / `pre-commit` ジョブが失敗していた
- `[tool.ruff.format]` に `exclude = ["*.md"]` を追加して Markdown を整形対象から外す

## 背景

PR #70 で `PLR0917` を ignore に追加したが、CI は解消しなかった。再調査したところ、`PLR0917`（lint）は正しく解消されており、残っていた失敗は **`ruff format --check`** によるものだった。

```
5 files would be reformatted, 79 files already formatted
```

対象ファイル:

- `docs/Completed/decisions/001-ellipse-based-background-removal.md`
- `docs/Completed/implementation_notes.md`
- `docs/Completed/implementation_plan.md`
- `docs/Completed/testing_strategy.md`
- `docs/Completed/troubleshooting.md`

`docs/Completed` は完了済みの設計記録で、擬似コード断片や意図的な引数グルーピングを含むため、自動整形は文書の意図を壊す（例: `implementation_plan.md` の `_run_wizard` シグネチャが 120 桁 1 行に潰れる）。ruff には Markdown 整形の ON/OFF 専用オプションがないため、`[tool.ruff.format] exclude` で除外する。lint（`ruff check`）の挙動には影響しない。

## 検証（ruff 0.16.0 で実行）

- `ruff format --check .` → `65 files already formatted`（修正前は `5 files would be reformatted`）
- `ruff check .` → `All checks passed!`
- pre-commit 全フック（format / lint / basedpyright / pytest / bandit）Passed

## 関連 PR

- Renovate PR #67: `chore(deps-python): update dependency ruff to >=0.16.0`
- Renovate PR #69: `chore(deps): lock file maintenance`
- PR #70: `PLR0917` 対応（有効だが不十分だった）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
